### PR TITLE
add windows ci (fixes #2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build for windows
         if: matrix.os == 'windows-latest'
         run: |
-          cargo build --all-features -v
+          cargo build --all-features
       - name: Run tests
         run: cargo test --all-features
         continue-on-error: ${{ matrix.rust == 'nightly' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
           - stable
           - beta
           - nightly
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -35,6 +35,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y cmake libclang-dev libc++-dev gcc-multilib
           cargo build --all-features
+      - name: Build for windows
+        if: matrix.os == 'windows-latest'
+        run: |
+          cargo build --all-features -v
       - name: Run tests
         run: cargo test --all-features
         continue-on-error: ${{ matrix.rust == 'nightly' }}


### PR DESCRIPTION
Adding Windows CI to see if it even requires anything special. ~Starting from the original vaaaanquish main branch to make it easier to add as a pull request there too, but that means that the (push) CI will fail, and only the (pull request) CI has any meaning.~ Never mind, cherry picked to a newer starting point to avoid trouble with the submodules.