### PR TITLE
Train with validation data CU-861n1bn7h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ lightgbm-sys/target
 examples/binary_classification/target/
 examples/multiclass_classification/target/
 examples/regression/target/
+
+.idea

--- a/examples/multiclass_classification/src/main.rs
+++ b/examples/multiclass_classification/src/main.rs
@@ -63,7 +63,7 @@ fn main() -> std::io::Result<()> {
         }
     };
 
-    let booster = Booster::train(train_dataset, &params).unwrap();
+    let booster = Booster::train(train_dataset, None, &params).unwrap();
     let result = booster.predict(test_features).unwrap();
 
     let mut tp = 0;

--- a/src/booster.rs
+++ b/src/booster.rs
@@ -69,9 +69,9 @@ impl Booster {
     ///         "metric": "auc"
     ///     }
     /// };
-    /// let bst = Booster::train(dataset, &params).unwrap();
+    /// let bst = Booster::train(dataset, None, &params).unwrap();
     /// ```
-    pub fn train(dataset: Dataset, parameter: &Value) -> Result<Self> {
+    pub fn train(train_data: Dataset, val_data: Option<Dataset> ,parameter: &Value) -> Result<Self> {
         // get num_iterations
         let num_iterations: i64 = if parameter["num_iterations"].is_null() {
             100
@@ -91,7 +91,7 @@ impl Booster {
 
         let mut handle = std::ptr::null_mut();
         lgbm_call!(lightgbm_sys::LGBM_BoosterCreate(
-            dataset.handle,
+            train_data.handle,
             params_cstring.as_ptr() as *const c_char,
             &mut handle
         ))?;
@@ -307,7 +307,7 @@ mod tests {
 
     fn _train_booster(params: &Value) -> Booster {
         let dataset = _read_train_file().unwrap();
-        Booster::train(dataset, &params).unwrap()
+        Booster::train(dataset, None, &params).unwrap()
     }
 
     fn _default_params() -> Value {

--- a/src/booster.rs
+++ b/src/booster.rs
@@ -131,7 +131,7 @@ impl Booster {
                     let v_formatted = a.iter().map(|x| x.to_string() + ",").collect::<String>();
                     let v_formatted = v_formatted
                         .replace("\",\"", ",")
-                        .trim_end_matches(",")
+                        .trim_end_matches(',')
                         .to_string();
                     (k, v_formatted)
                 }
@@ -285,7 +285,7 @@ impl Booster {
             .collect::<Vec<_>>();
         lgbm_call!(lightgbm_sys::LGBM_BoosterGetEvalNames(
             self.handle,
-            num_metrics as i32,
+            num_metrics,
             &mut num_eval_names,
             metric_name_length as u64,
             &mut out_buffer_len,

--- a/src/booster.rs
+++ b/src/booster.rs
@@ -294,7 +294,11 @@ impl Booster {
         /////////////////////////////////////////////////////////////////////
         // sanity check
         /////////////////////////////////////////////////////////////////////
-        assert_eq!(num_eval_names, num_metrics);
+        if num_eval_names != num_metrics {
+            return Err(Error::new(format!(
+                "expected num_eval_names==num_metrics, but got {num_eval_names}!={num_metrics}. This is a bug in lightgbm or its rust wrapper"
+            )));
+        }
 
         /////////////////////////////////////////////////////////////////////
         // get the actual strings

--- a/src/booster.rs
+++ b/src/booster.rs
@@ -149,7 +149,8 @@ impl Booster {
             &mut handle
         ))?;
 
-        if let Some(validation_data) = val_data {
+        // the following has to borrow val_data to avoid dropping the dataset
+        if let Some(validation_data) = &val_data {
             lgbm_call!(lightgbm_sys::LGBM_BoosterAddValidData(
                 handle,
                 validation_data.handle
@@ -486,7 +487,6 @@ mod tests {
         assert_eq!(eval_names, vec!["auc", "l1"])
     }
 
-    #[ignore]
     #[test]
     fn get_eval_broken() {
         let params = json! {


### PR DESCRIPTION
#### Changes:

This implements the addition of a validation set for training and the retrieval of the train/validation score. A bug in the JSON parser for the train params has been fixed, which lets you now specify an array of values for a key. Additionally, bins can now be aligned between datasets, that are loaded from a file.

#### Problems:

With this implementation, only one validation set can be added.
This pull request breaks the current API by additionally requiring an Optional for the `train` and `from_file` methods.
Additionally, I found an instance where the addition of a big validation dataset leads to a segfault in the train step. See the ignored` test.

#### Possible Solutions

API Changes & only one validation set: This could be changed by changing the API to a builder pattern (as already mentioned). I thought of something along those lines:

```rust

let booster = Booster::new(&params)
    .train_data(...)
    .validation_data(...)
    .validation_data(...)
    .validation_data(...)
    .train_step_callback(...)
    .train_step_callback(...)
    .fit() // or fit_predict()

```

The callbacks could also be used for #6 and maybe should be done together with #3.
As for the broken test: I am not sure what is causing the segfault and I hope that I just somehow just load/handle the validation data wrong.
