### PR TITLE
fix unsoundness of eval_names

### DIFF
--- a/src/booster.rs
+++ b/src/booster.rs
@@ -294,7 +294,11 @@ impl Booster {
         /////////////////////////////////////////////////////////////////////
         // sanity check
         /////////////////////////////////////////////////////////////////////
-        assert_eq!(num_eval_names, num_metrics);
+        if num_eval_names != num_metrics {
+            return Err(Error::new(format!(
+                "expected num_eval_names==num_metrics, but got {num_eval_names}!={num_metrics}. This is a bug in lightgbm or its rust wrapper"
+            )));
+        }
 
         /////////////////////////////////////////////////////////////////////
         // get the actual strings


### PR DESCRIPTION
A PR against the changes in #10 to make `eval_names` closer to how we deal with strings in `deepsign-wininput`, just without the unsafe code (consequently this zero-initializes the buffers). It's superior to the existing version of `eval_names` in that it doesn't truncate long names, and doesn't crash the tests with access violations

Edit: there is definetly some unsoundness somewhere else, but the eval_names test seems to work wit these changes. The get_eval test still doesn't.