### PR TITLE
update bindgen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ exclude = [".gitignore", ".gitmodules", "examples", "lightgbm-sys"]
 [dependencies]
 lightgbm-sys = { path = "lightgbm-sys", version = "0.3.0" }
 libc = "0.2.81"
-derive_builder = "0.5.1"
+derive_builder = "0.12.0"
 serde_json = "1.0.59"
-polars = {version = "0.16.0", optional = true}
+polars = { version = "0.16.0", optional = true }
 
 
 [features]

--- a/lightgbm-sys/Cargo.toml
+++ b/lightgbm-sys/Cargo.toml
@@ -7,11 +7,37 @@ license = "MIT"
 repository = "https://github.com/vaaaaanquish/LightGBM"
 description = "Native bindings to the LightGBM library"
 readme = "README.md"
-exclude = ["README.md", ".gitlab-ci.yml", ".hgeol", ".gitignore", ".appveyor.yml", ".coveralls.yml", ".travis.yml", ".github", ".gitmodules", ".nuget", "**/*.md", "lightgbm/compute/doc", "lightgbm/compute/example", "lightgbm/compute/index.html", "lightgbm/compute/perf", "lightgbm/compute/test", "lightgbm/eigen/debug", "lightgbm/eigen/demos", "lightgbm/eigen/doc", "lightgbm/eigen/failtest", "lightgbm/eigen/test", "lightgbm/examples", "lightgbm/external_libs/fast_double_parser/benchmarks", "lightgbm/external_libs/fmt/doc", "lightgbm/external_libs/fmt/test"]
+exclude = [
+    "README.md",
+    ".gitlab-ci.yml",
+    ".hgeol",
+    ".gitignore",
+    ".appveyor.yml",
+    ".coveralls.yml",
+    ".travis.yml",
+    ".github",
+    ".gitmodules",
+    ".nuget",
+    "**/*.md",
+    "lightgbm/compute/doc",
+    "lightgbm/compute/example",
+    "lightgbm/compute/index.html",
+    "lightgbm/compute/perf",
+    "lightgbm/compute/test",
+    "lightgbm/eigen/debug",
+    "lightgbm/eigen/demos",
+    "lightgbm/eigen/doc",
+    "lightgbm/eigen/failtest",
+    "lightgbm/eigen/test",
+    "lightgbm/examples",
+    "lightgbm/external_libs/fast_double_parser/benchmarks",
+    "lightgbm/external_libs/fmt/doc",
+    "lightgbm/external_libs/fmt/test",
+]
 
 [dependencies]
 libc = "0.2.81"
 
 [build-dependencies]
-bindgen = "0.56.0"
+bindgen = "0.69.1"
 cmake = "0.1"

--- a/lightgbm-sys/build.rs
+++ b/lightgbm-sys/build.rs
@@ -45,6 +45,7 @@ fn main() {
 
     // bindgen build
     let bindings = bindgen::Builder::default()
+        .size_t_is_usize(true)
         .header("wrapper.h")
         .clang_args(&["-x", "c++", "-std=c++11"])
         .clang_arg(format!("-I{}", lgbm_root.join("include").display()))

--- a/src/booster.rs
+++ b/src/booster.rs
@@ -189,7 +189,7 @@ impl Booster {
             self.handle,
             num_feature as i32,
             &mut num_feature_names,
-            feature_name_length as u64,
+            feature_name_length,
             &mut out_buffer_len,
             out_strs.as_ptr() as *mut *mut c_char
         ))?;


### PR DESCRIPTION
The old bindgen version doesn't work with clang 16, this update should fix that. Polars could also use an update, but I didn't want to dive into what changed in the last ~20 versions of a library I never used on the rust side